### PR TITLE
Allow multiple namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,19 @@ $ export SECRETLY_NAMESPACE=foo/bar
 $ secretly env | grep BAZ
 BAZ=mysecretpassword
 ```
+In addition, it's possible to specify multiple namespaces by separating them with commas in the `SECRETLY_NAMESPACE` variable.
 
-This is meant to have a very specific and lightweight purpose -- to be called from a Dockerfile. Add it to your Dockerfile, `chmod +x` it, and prefix your `CMD` or `ENTRYPOINT` with it -- `CMD ["secretly", "run_myawesomeapp.sh"]`.  Check out the trivial example in [example.Dockerfile](example.Dockerfile).
+```bash
+$ secretly env | grep APP
+# nothing
+$ export SECRETLY_NAMESPACE=common/dev,myapp/dev
+$ secretly env | grep APP
+APP_SHARED_API_KEY=mysecretpassword
+APP_MYAPP_SECRET=mysecretpassword
+```
+
+
+Secretly is meant to have a very specific and lightweight purpose -- to be called from a Dockerfile. Add it to your Dockerfile, `chmod +x` it, and prefix your `CMD` or `ENTRYPOINT` with it -- `CMD ["secretly", "run_myawesomeapp.sh"]`.  Check out the trivial example in [example.Dockerfile](example.Dockerfile).
 
 Now:
 ```bash

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ export SECRETLY_NAMESPACE=foo/bar
 $ secretly env | grep BAZ
 BAZ=mysecretpassword
 ```
-In addition, it's possible to specify multiple namespaces by separating them with commas in the `SECRETLY_NAMESPACE` variable.
+In addition, it's possible to specify multiple namespaces by separating them with commas in the `SECRETLY_NAMESPACE` variable.  If a parameter is defined in multiple namespaces, the parameter from the right-most entry in the comma separated list of namespaces will be returned.
 
 ```bash
 $ secretly env | grep APP

--- a/integration_test.go
+++ b/integration_test.go
@@ -40,6 +40,7 @@ func Test_cliEnv(t *testing.T) {
 		{"totally empty", []string{}, []string{}, false},
 		{"passes through", []string{"FOO_BAR=BAZ"}, []string{"FOO_BAR=BAZ"}, false},
 		{"AWS error", []string{"SECRETLY_NAMESPACE=BAZ"}, nil, true},
+		{"AWS error multiple namespaces", []string{"SECRETLY_NAMESPACE=BAZ,BAR"}, nil, true},
 	}
 
 	for _, tt := range tests {
@@ -50,7 +51,6 @@ func Test_cliEnv(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			cmd := exec.Command(binPath, envPath)
 			cmd.Env = tt.environ
 			out, err := cmd.Output()

--- a/main.go
+++ b/main.go
@@ -29,12 +29,15 @@ func main() {
 		session := session.Must(session.NewSession())
 		svc := ssm.New(session)
 
-		secrets, err := findSecrets(svc, ns)
-		if err != nil {
-			log.Fatal(err)
+		nsList := strings.Split(ns, ",")
+		for i := range nsList {
+			log.Print(i)
+			secrets, err := findSecrets(svc, nsList[i])
+			if err != nil {
+				log.Fatal(err)
+			}
+			environ = addSecrets(environ, secrets)
 		}
-
-		environ = addSecrets(environ, secrets)
 	}
 
 	if err := run(os.Args[1:], environ); err != nil {

--- a/main.go
+++ b/main.go
@@ -31,7 +31,6 @@ func main() {
 
 		nsList := strings.Split(ns, ",")
 		for i := range nsList {
-			log.Print(i)
 			secrets, err := findSecrets(svc, nsList[i])
 			if err != nil {
 				log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
 )
 
 const (
@@ -36,17 +37,22 @@ func main() {
 	}
 }
 
-func findAllSecrets(svc ssmiface.SSMAPI, nsAll string, environ []string) ([]string) {
+func findAllSecrets(svc ssmiface.SSMAPI, nsAll string, environ []string) []string {
+	allSecrets := make(map[string]string)
 	for _, nsItem := range strings.Split(nsAll, ",") {
-		secrets, err := findSecrets(svc, nsItem)
-		if err != nil {
-			log.Fatal(err)
+		if len(nsItem) > 0 {
+			secrets, err := findSecrets(svc, nsItem)
+			if err != nil {
+				log.Fatal(err)
+			}
+			for key, value := range secrets {
+				allSecrets[key] = value
+			}
 		}
-		environ = addSecrets(environ, secrets)
 	}
+	environ = addSecrets(environ, allSecrets)
 	return environ
 }
-
 
 func addSecrets(environ []string, secrets map[string]string) []string {
 	if len(secrets) == 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -149,6 +149,114 @@ func Test_findSecrets(t *testing.T) {
 	}
 }
 
+func Test_findAllSecrets(t *testing.T) {
+	type args struct {
+		getter func(input *ssm.GetParametersByPathInput) (*ssm.GetParametersByPathOutput, error)
+		ns     string
+	}
+	sharedGetter := func(input *ssm.GetParametersByPathInput) (*ssm.GetParametersByPathOutput, error) {
+		if *input.Path == "/prefix/1/" {
+			if input.NextToken == nil {
+				return &ssm.GetParametersByPathOutput{
+					NextToken: aws.String("2"),
+					Parameters: []*ssm.Parameter{
+						{
+							Name:  aws.String("/prefix/1/VALUE_FIRST_ONLY"),
+							Value: aws.String("I CAME FROM PREFIX 1"),
+						},
+					},
+				}, nil
+			} else {
+				return &ssm.GetParametersByPathOutput{
+					NextToken: nil,
+					Parameters: []*ssm.Parameter{
+						{
+							Name:  aws.String("/prefix/1/VALUE_IN_BOTH"),
+							Value: aws.String("I CAME FROM PREFIX 1"),
+						},
+					},
+				}, nil
+			}
+		}
+		if *input.Path == "/prefix/2/" {
+			if input.NextToken == nil {
+				return &ssm.GetParametersByPathOutput{
+					NextToken: aws.String("2"),
+					Parameters: []*ssm.Parameter{
+						{
+							Name:  aws.String("/prefix/2/VALUE_SECOND_ONLY"),
+							Value: aws.String("I CAME FROM PREFIX 2"),
+						},
+					},
+				}, nil
+			} else {
+				return &ssm.GetParametersByPathOutput{
+					NextToken: nil,
+					Parameters: []*ssm.Parameter{
+						{
+							Name:  aws.String("/prefix/2/VALUE_IN_BOTH"),
+							Value: aws.String("I CAME FROM PREFIX 2"),
+						},
+					},
+				}, nil
+			}
+		}
+		// these are returned when empty prefix is sent.
+		return &ssm.GetParametersByPathOutput{
+			NextToken: nil,
+			Parameters: []*ssm.Parameter{
+			},
+		}, nil
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "basicFindAllTest",
+			args: args{
+				getter: sharedGetter,
+				ns: "prefix/1,,,,,prefix/2",
+			},
+			want: []string {
+				"VALUE_FIRST_ONLY=I CAME FROM PREFIX 1",
+				"VALUE_IN_BOTH=I CAME FROM PREFIX 2",
+				"VALUE_SECOND_ONLY=I CAME FROM PREFIX 2",
+			},
+			wantErr: false,
+		},
+		{
+			name: "ReversedPrefixOrderFindAllTest",
+			args: args{
+				getter: sharedGetter,
+				ns: "prefix/2,prefix/1",
+			},
+			want: []string {
+				"VALUE_FIRST_ONLY=I CAME FROM PREFIX 1",
+				"VALUE_IN_BOTH=I CAME FROM PREFIX 1",
+				"VALUE_SECOND_ONLY=I CAME FROM PREFIX 2",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockClient{getter: tt.args.getter}
+			var environ []string
+			got := findAllSecrets(client, tt.args.ns, environ)
+
+			sort.Strings(got)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findAllSecrets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 type mockClient struct {
 	ssmiface.SSMAPI
 	getter func(input *ssm.GetParametersByPathInput) (*ssm.GetParametersByPathOutput, error)

--- a/main_test.go
+++ b/main_test.go
@@ -213,7 +213,6 @@ func Test_findAllSecrets(t *testing.T) {
 		name    string
 		args    args
 		want    []string
-		wantErr bool
 	}{
 		{
 			name: "basicFindAllTest",
@@ -226,7 +225,6 @@ func Test_findAllSecrets(t *testing.T) {
 				"VALUE_IN_BOTH=I CAME FROM PREFIX 2",
 				"VALUE_SECOND_ONLY=I CAME FROM PREFIX 2",
 			},
-			wantErr: false,
 		},
 		{
 			name: "ReversedPrefixOrderFindAllTest",
@@ -239,7 +237,6 @@ func Test_findAllSecrets(t *testing.T) {
 				"VALUE_IN_BOTH=I CAME FROM PREFIX 1",
 				"VALUE_SECOND_ONLY=I CAME FROM PREFIX 2",
 			},
-			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
With this change, you can specify multiple AWS Parameter Store namespaces by separating them by a comma in the SECRETLY_NAMESPACE environment variable like so:

`SECRETLY_NAMESPACE='global/dev,myapp/dev' ./dist/secretly-darwin-amd64 env
`

This has the effect of creating environment variables for both 'global/dev' and 'myapp/dev' Parameter store paths.  If a variable is defined in both, the last one will override any previous entries.


