### PR TITLE
Build status badge uses main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/energyhub/secretly.svg?branch=master)](https://travis-ci.com/energyhub/secretly)
+[![Build Status](https://travis-ci.com/energyhub/secretly.svg?branch=main)](https://travis-ci.com/energyhub/secretly)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a60928ed98774f86881108286d1c9e20)](https://www.codacy.com/app/energyhub/secretly?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=energyhub/secretly&amp;utm_campaign=Badge_Grade)
 [![Go Report Card](https://goreportcard.com/badge/github.com/energyhub/secretly)](https://goreportcard.com/report/github.com/energyhub/secretly)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/a60928ed98774f86881108286d1c9e20)](https://www.codacy.com/app/energyhub/secretly?utm_source=github.com&utm_medium=referral&utm_content=energyhub/secretly&utm_campaign=Badge_Coverage)


### PR DESCRIPTION
Updates branch used on for build status badge to reflect EH's current default branch name